### PR TITLE
#2: Use "dns_name" attribute as primary source for RR name

### DIFF
--- a/model/nx_models.go
+++ b/model/nx_models.go
@@ -25,8 +25,16 @@ type Tag struct {
 type IPAddress struct {
 	ID          int    `json:"id"`
 	Address     string `json:"address"`
-	Name        string `json:"dns_name"`
+	DnsName     string `json:"dns_name"`
 	Description string `json:"description"`
 	Tags        []Tag  `json:"tags"`
 	Prefix      *IPAMPrefix
+}
+
+func (i IPAddress) GetName() string {
+	if i.DnsName == "" {
+		return i.Description
+	} else {
+		return i.DnsName
+	}
 }

--- a/model/nx_models.go
+++ b/model/nx_models.go
@@ -23,9 +23,10 @@ type Tag struct {
 }
 
 type IPAddress struct {
-	ID      int    `json:"id"`
-	Address string `json:"address"`
-	Name    string `json:"description"`
-	Tags    []Tag  `json:"tags"`
-	Prefix  *IPAMPrefix
+	ID          int    `json:"id"`
+	Address     string `json:"address"`
+	Name        string `json:"dns_name"`
+	Description string `json:"description"`
+	Tags        []Tag  `json:"tags"`
+	Prefix      *IPAMPrefix
 }

--- a/ns/dns/namefixing_test.go
+++ b/ns/dns/namefixing_test.go
@@ -1,9 +1,8 @@
 package dns
 
 import (
+	"peg.nu/nx/model"
 	"testing"
-
-	"peg.nu/nx/netbox"
 )
 
 func TestDomainNormalizing(t *testing.T) {
@@ -42,24 +41,25 @@ func TestDomainNormalizing(t *testing.T) {
 	})
 }
 
-func makeAddress(name, zone string) netbox.IPAddress {
-	return netbox.IPAddress{
-		Name: name,
-		GenOptions: netbox.GenerateOptions{
-			ForwardZoneName: zone,
+func makeAddress(name, zone string) DNSIP {
+	return DNSIP{
+		IP: &model.IPAddress{
+			Name: name,
 		},
+
+		ForwardZoneName: zone,
 	}
 }
 
-func testNameFixing(original, expect netbox.IPAddress, t *testing.T) {
+func testNameFixing(original, expect DNSIP, t *testing.T) {
 	updated := original
 	FixFlattenAddress(&updated)
 
-	if updated.Name != expect.Name {
-		t.Errorf("Expected Name to be <%s>; but was <%s>", expect.Name, updated.Name)
+	if updated.IP.Name != expect.IP.Name {
+		t.Errorf("Expected Name to be <%s>; but was <%s>", expect.IP.Name, updated.IP.Name)
 	}
 
-	if updated.GenOptions.ForwardZoneName != expect.GenOptions.ForwardZoneName {
-		t.Errorf("Expected Zone to be <%s>; but was <%s>", expect.GenOptions.ForwardZoneName, updated.GenOptions.ForwardZoneName)
+	if updated.ForwardZoneName != expect.ForwardZoneName {
+		t.Errorf("Expected Zone to be <%s>; but was <%s>", expect.ForwardZoneName, updated.ForwardZoneName)
 	}
 }

--- a/ns/dns/namefixing_test.go
+++ b/ns/dns/namefixing_test.go
@@ -7,44 +7,57 @@ import (
 
 func TestDomainNormalizing(t *testing.T) {
 	t.Run("min-min", func(t *testing.T) {
-		testNameFixing(makeAddress("vm-ns-1", "peg.nu"), makeAddress("vm-ns-1", "peg.nu"), t)
+		testNameFixing(makeAddress("vm-ns-1", "", "peg.nu"), makeAddress("vm-ns-1", "", "peg.nu"), t)
 	})
 	t.Run("max-min", func(t *testing.T) {
-		testNameFixing(makeAddress("vm-ns-1.peg.nu", "peg.nu"), makeAddress("vm-ns-1", "peg.nu"), t)
+		testNameFixing(makeAddress("vm-ns-1.peg.nu", "", "peg.nu"), makeAddress("vm-ns-1", "", "peg.nu"), t)
 	})
 	t.Run("max-max", func(t *testing.T) {
-		testNameFixing(makeAddress("vm-ns-1.bue39.peg.nu", "bue39.peg.nu"), makeAddress("vm-ns-1.bue39", "peg.nu"), t)
+		testNameFixing(makeAddress("vm-ns-1.bue39.peg.nu", "", "bue39.peg.nu"), makeAddress("vm-ns-1.bue39", "", "peg.nu"), t)
 	})
 	t.Run("mid-max", func(t *testing.T) {
-		testNameFixing(makeAddress("vm-ns-1.bue39", "bue39.peg.nu"), makeAddress("vm-ns-1.bue39.bue39", "peg.nu"), t)
+		testNameFixing(makeAddress("vm-ns-1.bue39", "", "bue39.peg.nu"), makeAddress("vm-ns-1.bue39.bue39", "", "peg.nu"), t)
 	})
 	t.Run("maxadd-min", func(t *testing.T) {
-		testNameFixing(makeAddress("plex.rack.farm v4", "rack.farm"), makeAddress("plex", "rack.farm"), t)
+		testNameFixing(makeAddress("plex.rack.farm v4", "", "rack.farm"), makeAddress("plex", "", "rack.farm"), t)
 	})
 	t.Run("minadd-min", func(t *testing.T) {
-		testNameFixing(makeAddress("plex and some text", "rack.farm"), makeAddress("plex", "rack.farm"), t)
+		testNameFixing(makeAddress("plex and some text", "", "rack.farm"), makeAddress("plex", "", "rack.farm"), t)
 	})
 	t.Run("add-min", func(t *testing.T) {
-		testNameFixing(makeAddress("just some text", "peg.nu"), makeAddress("just", "peg.nu"), t)
+		testNameFixing(makeAddress("just some text", "", "peg.nu"), makeAddress("just", "", "peg.nu"), t)
 	})
 	t.Run("max-min", func(t *testing.T) {
-		testNameFixing(makeAddress("plex.plox.rack.farm", "rack.farm"), makeAddress("plex.plox", "rack.farm"), t)
+		testNameFixing(makeAddress("plex.plox.rack.farm", "", "rack.farm"), makeAddress("plex.plox", "", "rack.farm"), t)
 	})
 	t.Run("min-umin", func(t *testing.T) {
-		testNameFixing(makeAddress("nas", "intra"), makeAddress("nas", "intra"), t)
+		testNameFixing(makeAddress("nas", "", "intra"), makeAddress("nas", "", "intra"), t)
 	})
 	t.Run("max-umin", func(t *testing.T) {
-		testNameFixing(makeAddress("nas.intra", "intra"), makeAddress("nas", "intra"), t)
+		testNameFixing(makeAddress("nas.intra", "", "intra"), makeAddress("nas", "", "intra"), t)
 	})
 	t.Run("minadd-umin", func(t *testing.T) {
-		testNameFixing(makeAddress("nas und so", "intra"), makeAddress("nas", "intra"), t)
+		testNameFixing(makeAddress("nas und so", "", "intra"), makeAddress("nas", "", "intra"), t)
 	})
 }
 
-func makeAddress(name, zone string) DNSIP {
+func TestDnsFieldFallback(t *testing.T) {
+	t.Run("DnsName only", func(t *testing.T) {
+		testDnsFieldPreference(makeAddress("fabianflu.ch", "", ""), "fabianflu.ch", t)
+	})
+	t.Run("Both fields", func(t *testing.T) {
+		testDnsFieldPreference(makeAddress("fabianflu.ch", "peg.nu", ""), "fabianflu.ch", t)
+	})
+	t.Run("Description only", func(t *testing.T) {
+		testDnsFieldPreference(makeAddress("", "peg.nu", ""), "peg.nu", t)
+	})
+}
+
+func makeAddress(dnsName, description, zone string) DNSIP {
 	return DNSIP{
 		IP: &model.IPAddress{
-			Name: name,
+			DnsName:     dnsName,
+			Description: description,
 		},
 
 		ForwardZoneName: zone,
@@ -55,11 +68,18 @@ func testNameFixing(original, expect DNSIP, t *testing.T) {
 	updated := original
 	FixFlattenAddress(&updated)
 
-	if updated.IP.Name != expect.IP.Name {
-		t.Errorf("Expected Name to be <%s>; but was <%s>", expect.IP.Name, updated.IP.Name)
+	if updated.IP.DnsName != expect.IP.GetName() {
+		t.Errorf("Expected Name to be <%s>; but was <%s>", expect.IP.GetName(), updated.IP.GetName())
 	}
 
 	if updated.ForwardZoneName != expect.ForwardZoneName {
 		t.Errorf("Expected Zone to be <%s>; but was <%s>", expect.ForwardZoneName, updated.ForwardZoneName)
+	}
+}
+func testDnsFieldPreference(a DNSIP, expect string, t *testing.T) {
+
+	if a.IP.GetName() != expect {
+		t.Errorf("Expected Hostname to be <%s>; but was <%s>", expect, a.IP.GetName())
+
 	}
 }

--- a/ns/dns/zonegenerator.go
+++ b/ns/dns/zonegenerator.go
@@ -178,8 +178,15 @@ func GenerateZones(addresses []model.IPAddress, defaultSoaInfo SOAInfo, conf *co
 				recordType = Aaaa
 			}
 
+			var name string
+			if address.Name != "" {
+				name = address.Name
+			} else {
+				name = address.Description
+			}
 			putMap(zoneRecordsMap, dnsIP.ForwardZoneName, resourceRecord{
-				Name:  address.Name,
+
+				Name:  name,
 				Type:  recordType,
 				RData: ip.String(),
 			})

--- a/ns/wg/wireguard.go
+++ b/ns/wg/wireguard.go
@@ -54,7 +54,7 @@ func GenerateWgConfigs(ips []model.IPAddress, conf *config.NXConfig) {
 			continue
 		}
 
-		peer.Name = ip.Name
+		peer.Name = ip.GetName()
 		putMap(vpnPeers, ip.Prefix.EnOptions.WGVpnName, parsedIp{IP: ip, peer: peer})
 	}
 
@@ -77,7 +77,7 @@ func GenerateWgConfigs(ips []model.IPAddress, conf *config.NXConfig) {
 			data := templateData{
 				OwnAddress: peer.IP.Address,
 				OwnPort:    peer.peer.Port,
-				ServerName: peer.IP.Name,
+				ServerName: peer.IP.GetName(),
 				Peers:      peersWithoutCurrent,
 			}
 

--- a/tagparser/tagparser_test.go
+++ b/tagparser/tagparser_test.go
@@ -15,6 +15,7 @@ type TestingStruct struct {
 	IntSlice      []int    `nx:"intsl,ns:test"`
 	Empty         string
 	NotOverridden string `nx:"nov,ns:test"`
+	Boolean       bool   `nx:"bol,ns:test"`
 }
 
 func TestTagParsing(t *testing.T) {
@@ -25,6 +26,7 @@ func TestTagParsing(t *testing.T) {
 		OtherNs:       "someOtherString",
 		IntSlice:      []int{1, 2, 3},
 		NotOverridden: "",
+		Boolean:       false,
 	}
 	actual := TestingStruct{}
 	pTags := []model.Tag{
@@ -36,6 +38,7 @@ func TestTagParsing(t *testing.T) {
 		{Name: "nx:test2:sons[someOtherString]"},
 		{Name: "nx:test:intsl[1]"}, {Name: "nx:test:intsl[2]"}, {Name: "nx:test:intsl[3]"}, {Name: "nx:test:intsl[invalidIntSlice]"},
 		{Name: "nx:test:nov[]"},
+		{Name: "nx:test:bol[false]"},
 	}
 
 	ParseTags(&actual, tags, pTags)

--- a/tagparser/tagparser_test.go
+++ b/tagparser/tagparser_test.go
@@ -1,6 +1,7 @@
 package tagparser
 
 import (
+	"peg.nu/nx/model"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -26,13 +27,15 @@ func TestTagParsing(t *testing.T) {
 		NotOverridden: "",
 	}
 	actual := TestingStruct{}
-	pTags := []string{"nx:test:string[overriddenValue]", "nx:test:int[invalidInt]", "nx:test:int[42]", "nx:test:nov[false]"}
-	tags := []string{
-		"nx:test:string[someString]", "nx:text:string[shouldBeIgnored]",
-		"nx:test:strsl[strings]", "nx:test:strsl[may]", "nx:test:strsl[slice]",
-		"nx:test2:sons[someOtherString]",
-		"nx:test:intsl[1]", "nx:test:intsl[2]", "nx:test:intsl[3]", "nx:test:intsl[invalidIntSlice]",
-		"nx:test:nov[]",
+	pTags := []model.Tag{
+		{Name: "nx:test:string[overriddenValue]"}, {Name: "nx:test:int[invalidInt]"}, {Name: "nx:test:int[42]"}, {Name: "nx:test:nov[false]"},
+	}
+	tags := []model.Tag{
+		{Name: "nx:test:string[someString]"}, {Name: "nx:text:string[shouldBeIgnored]"},
+		{Name: "nx:test:strsl[strings]"}, {Name: "nx:test:strsl[may]"}, {Name: "nx:test:strsl[slice]"},
+		{Name: "nx:test2:sons[someOtherString]"},
+		{Name: "nx:test:intsl[1]"}, {Name: "nx:test:intsl[2]"}, {Name: "nx:test:intsl[3]"}, {Name: "nx:test:intsl[invalidIntSlice]"},
+		{Name: "nx:test:nov[]"},
 	}
 
 	ParseTags(&actual, tags, pTags)


### PR DESCRIPTION
Add ability to use the DNS field instead of the description for the hostname.

Fixes #2 