### PR TITLE
On Demand Hashing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1 as builder
+FROM golang:1 AS builder
 LABEL maintainer="Joel Messerli <hi.github@peg.nu>"
 WORKDIR /go/src/github.com/jmesserli/nx
 COPY . .
 RUN go get -d -v ./...
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /go/bin/nx .
 
-FROM alpine:latest
+FROM alpine:3
 RUN apk --no-cache add ca-certificates tzdata
 WORKDIR /root/
 COPY --from=builder /go/bin/nx .

--- a/cache/cached_writer.go
+++ b/cache/cached_writer.go
@@ -41,9 +41,8 @@ func (cw *CachedTemplateWriter) WriteTemplate(
 	err := func() error {
 		var bufWriter io.Writer
 		if cw.useTabbedWriter {
-			tw := tabwriter.NewWriter(&buf, 2, 2, 2, ' ', 0)
-			bufWriter = tw
-			defer tw.Flush()
+			bufWriter = tabwriter.NewWriter(&buf, 2, 2, 2, ' ', 0)
+			defer bufWriter.(*tabwriter.Writer).Flush()
 		} else {
 			bufWriter = &buf
 		}

--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ func main() {
 
 	prefixIPsList := loadPrefixes(prefixes, nc)
 	sortPrefixList(prefixIPsList)
-	generateAll(prefixIPsList, dnsIps, wgIps, iplIps, conf)
+	generateAll(prefixIPsList, dnsIps, wgIps, iplIps, &conf)
 
 	logger.Println("Writing updated files report")
 	err := os.WriteFile("generated/updated_files.txt", []byte(strings.Join(conf.UpdatedFiles, "\n")), os.ModePerm)
@@ -78,7 +78,7 @@ func sortPrefixList(prefixIPsList []prefixIPs) {
 	}
 }
 
-func generateAll(prefixIPsList []prefixIPs, dnsIps []model.IPAddress, wgIps []model.IPAddress, iplIps []model.IPAddress, conf config.NXConfig) {
+func generateAll(prefixIPsList []prefixIPs, dnsIps []model.IPAddress, wgIps []model.IPAddress, iplIps []model.IPAddress, conf *config.NXConfig) {
 	defer util.DurationSince(util.StartTracking("generateAll"))
 
 	for _, prefixIP := range prefixIPsList {
@@ -103,14 +103,14 @@ func generateAll(prefixIPsList []prefixIPs, dnsIps []model.IPAddress, wgIps []mo
 
 		DottedMailResponsible: "unknown\\.admin.local",
 		NameserverFQDN:        "unknown-nameserver.local.",
-	}, &conf)
+	}, conf)
 
 	logger.Println("Generating BIND config files")
-	dns.GenerateConfigs(generatedZones, &conf)
+	dns.GenerateConfigs(generatedZones, conf)
 	logger.Println("Generating Wireguard config files")
-	wg.GenerateWgConfigs(wgIps, &conf)
+	wg.GenerateWgConfigs(wgIps, conf)
 	logger.Println("Generating IP lists")
-	ipl.GenerateIPLists(iplIps, &conf)
+	ipl.GenerateIPLists(iplIps, conf)
 }
 
 type prefixIPs struct {

--- a/ns/dns/configgenerator.go
+++ b/ns/dns/configgenerator.go
@@ -95,8 +95,10 @@ func GenerateConfigs(zones []string, conf *config.NXConfig) {
 		panic(err)
 	}
 	configTemplate := template.Must(template.New("config").Parse(string(templateString)))
-	cw := cache.New("generated/hashes/bind-config.json")
-	ignoreRegex := regexp.MustCompile("(?m)^ \\* Generated at.*$")
+	ignoreRegexes := []*regexp.Regexp{
+		regexp.MustCompile("(?m)^ \\* Generated at.*$"),
+	}
+	cw := cache.New(configTemplate, ignoreRegexes, false)
 
 	templateVars := configTemplateVars{
 		GeneratedAt: time.Now().Format(time.RFC3339),
@@ -156,10 +158,7 @@ func GenerateConfigs(zones []string, conf *config.NXConfig) {
 
 		_, err = cw.WriteTemplate(
 			fmt.Sprintf("generated/bind-config/%s.conf", currentMaster.Name),
-			configTemplate,
 			templateVars,
-			[]*regexp.Regexp{ignoreRegex},
-			false,
 		)
 		if err != nil {
 			panic(err)

--- a/ns/ipl/ipl.go
+++ b/ns/ipl/ipl.go
@@ -58,9 +58,11 @@ func GenerateIPLists(addresses []model.IPAddress, conf *config.NXConfig) {
 		panic(err)
 	}
 	iplTemplate := template.Must(template.New("ipl").Parse(string(templateString)))
+	ignoreRegexes := []*regexp.Regexp{
+		regexp.MustCompile("(?m)^# Generated at .*$"),
+	}
 
-	cw := cache.New("generated/hashes/ipl.json")
-	ignoreRegex := regexp.MustCompile("(?m)^# Generated at .*$")
+	cw := cache.New(iplTemplate, ignoreRegexes, false)
 
 	for group, ips := range groupMap {
 		vars.Name = group
@@ -68,10 +70,7 @@ func GenerateIPLists(addresses []model.IPAddress, conf *config.NXConfig) {
 
 		_, err := cw.WriteTemplate(
 			fmt.Sprintf("generated/ipl/%s.ipl.txt", group),
-			iplTemplate,
 			vars,
-			[]*regexp.Regexp{ignoreRegex},
-			false,
 		)
 		if err != nil {
 			panic(err)

--- a/ns/wg/wireguard.go
+++ b/ns/wg/wireguard.go
@@ -62,8 +62,8 @@ func GenerateWgConfigs(ips []model.IPAddress, conf *config.NXConfig) {
 	if err != nil {
 		panic(err)
 	}
-	zoneTemplate := template.Must(template.New("wg-config").Parse(string(templateString)))
-	cw := cache.New("generated/hashes/wg.json")
+	wgTemplate := template.Must(template.New("wg-config").Parse(string(templateString)))
+	cw := cache.New(wgTemplate, []*regexp.Regexp{}, false)
 
 	for vpnName, peers := range vpnPeers {
 		for _, peer := range peers {
@@ -82,11 +82,8 @@ func GenerateWgConfigs(ips []model.IPAddress, conf *config.NXConfig) {
 			}
 
 			_, err := cw.WriteTemplate(
-				fmt.Sprintf("generated/wg/%s_%s.conf", vpnName, data.ServerName),
-				zoneTemplate,
+				fmt.Sprintf("generated/wg/%s-%s.conf", vpnName, data.ServerName),
 				data,
-				[]*regexp.Regexp{},
-				false,
 			)
 			if err != nil {
 				panic(err)

--- a/tagparser/tagparser.go
+++ b/tagparser/tagparser.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 )
 
+const NoValueErrStr = "no value available"
+
 var tagRegex = regexp.MustCompile("^(\\w+),ns:(\\w+)$")
 
 type annotatedField struct {
@@ -103,7 +105,7 @@ func findValueForField(field annotatedField, tags []model.Tag) (interface{}, err
 
 		if sKind == reflect.String {
 			if len(strValues) == 0 {
-				return nil, fmt.Errorf("no value available")
+				return nil, fmt.Errorf(NoValueErrStr)
 			}
 			return strValues, nil
 		} else if sKind == reflect.Int {
@@ -123,14 +125,14 @@ func findValueForField(field annotatedField, tags []model.Tag) (interface{}, err
 	} else if fKind == reflect.String {
 		if len(strValues) == 0 {
 			//fmt.Printf("warn: No values available for string field <%s>. Returning empty string.\n", field.sField.Name)
-			return "", fmt.Errorf("no value available")
+			return "", fmt.Errorf(NoValueErrStr)
 		}
 
 		return strValues[0], nil
 	} else if fKind == reflect.Int {
 		if len(strValues) == 0 {
 			//fmt.Printf("warn: No values available for int field <%s>. Returning 0.\n", field.sField.Name)
-			return 0, fmt.Errorf("no value available")
+			return 0, fmt.Errorf(NoValueErrStr)
 		}
 
 		for _, val := range strValues {
@@ -144,11 +146,11 @@ func findValueForField(field annotatedField, tags []model.Tag) (interface{}, err
 		}
 
 		//fmt.Printf("warn: No values available for int field <%s>. Returning 0.\n", field.sField.Name)
-		return 0, fmt.Errorf("no value available")
+		return 0, fmt.Errorf(NoValueErrStr)
 	} else if fKind == reflect.Bool {
 		if len(strValues) == 0 {
 			//fmt.Printf("warn: No values available for bool field <%s>. Returning false.\n", field.sField.Name)
-			return false, fmt.Errorf("no value available")
+			return false, fmt.Errorf(NoValueErrStr)
 		}
 
 		for _, val := range strValues {
@@ -162,7 +164,7 @@ func findValueForField(field annotatedField, tags []model.Tag) (interface{}, err
 		}
 
 		//fmt.Printf("warn: No values available for bool field <%s>. Returning false.\n", field.sField.Name)
-		return false, fmt.Errorf("no value available")
+		return false, fmt.Errorf(NoValueErrStr)
 	}
 
 	panic(fmt.Sprintf("Unsupported field type <%v>", fKind))


### PR DESCRIPTION
The cached writer used hash files to store the hashes of the generated files until now. While this may be a bit better for I/O since it only needs to read the hash files, and not all of the generated files, this is probably irrelevant for our use case.

After changing it, I realized why that has been the case so far: it didn't work anymore ;)
I took a bit more time to debug it this time and figured out that the hashes were generated before the tabwriter could work its magic. Therefore the freshly generated files had `\t`s in there, and the files read from this had the tabs converted to spaces.

I fixed it by generating the files through the tabwriter into a buffer and then comparing that buffer to the existing files.

Also there was a bug where the config was not passed by reference which broke the updated files report.